### PR TITLE
Fixed test drive deployment errors

### DIFF
--- a/main-template.json
+++ b/main-template.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {},
     "variables": {
-        "baseUrl": "https://raw.githubusercontent.com/sophos-iaas/xg-azure-testdrive/master",
+        "baseUrl": "https://raw.githubusercontent.com/jornlutters/xg-azure-testdrive/master",
         "availabilitySetName": "avset",
         "apiVersion": "2015-01-01",
         "location": "[resourcegroup().location]",

--- a/main-template.json
+++ b/main-template.json
@@ -52,7 +52,7 @@
         "vmSize": "Standard_F2s_v2",
         "imagePublisher": "sophos",
         "imageOffer": "sophos-xg",
-        "imageSKU": "payg",
+        "imageSKU": "payg-new",
         "windowsVmName": "clientVm",
         "windowsVmSize": "Standard_D1_v2",
         "windows_ImagePublisher": "MicrosoftWindowsServer",

--- a/main-template.json
+++ b/main-template.json
@@ -49,7 +49,7 @@
         "nic_windowsPrivateIp": "172.18.1.5",
         "sophosvm": "xgvm",
         "sophosVmPassword": "XgPassword@123",
-        "vmSize": "Standard_D2",
+        "vmSize": "Standard_F2s_v2",
         "imagePublisher": "sophos",
         "imageOffer": "sophos-xg",
         "imageSKU": "payg",

--- a/main-template.json
+++ b/main-template.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {},
     "variables": {
-        "baseUrl": "https://raw.githubusercontent.com/jornlutters/xg-azure-testdrive/master",
+        "baseUrl": "https://raw.githubusercontent.com/sophos-iaas/xg-azure-testdrive/master",
         "availabilitySetName": "avset",
         "apiVersion": "2015-01-01",
         "location": "[resourcegroup().location]",

--- a/main-template.json
+++ b/main-template.json
@@ -54,7 +54,7 @@
         "imageOffer": "sophos-xg",
         "imageSKU": "payg-new",
         "windowsVmName": "clientVm",
-        "windowsVmSize": "Standard_D1_v2",
+        "windowsVmSize": "Standard_A2_v2",
         "windows_ImagePublisher": "MicrosoftWindowsServer",
         "windows_ImageOffer": "WindowsServer",
         "windows_ImageSKU": "2012-R2-Datacenter",

--- a/nested/availability-set.json
+++ b/nested/availability-set.json
@@ -22,37 +22,6 @@
         "location": {
             "type": "string",
             "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
         },
         "tag": {
             "type": "object",

--- a/nested/availability-set.json
+++ b/nested/availability-set.json
@@ -21,7 +21,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "westus",
+            "defaultValue": "westus"
         },
         "tag": {
             "type": "object",

--- a/nested/nic-windows.json
+++ b/nested/nic-windows.json
@@ -8,38 +8,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "Port_PrivateIp": {
             "defaultValue": "172.18.1.5",

--- a/nested/public-ip.json
+++ b/nested/public-ip.json
@@ -4,38 +4,7 @@
     "parameters": {
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "networkApiVersion": {
             "type": "string",

--- a/nested/routetable.json
+++ b/nested/routetable.json
@@ -4,38 +4,7 @@
     "parameters": {
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "routeTables_xglanrt_name": {
             "defaultValue": "xglanrt",

--- a/nested/storage.json
+++ b/nested/storage.json
@@ -21,38 +21,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "tag": {
             "type": "object",

--- a/nested/vnet.json
+++ b/nested/vnet.json
@@ -4,38 +4,7 @@
     "parameters": {
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "virtualNetworks_xgvnet_name": {
             "defaultValue": "xgvnet",

--- a/nested/windowsvm.json
+++ b/nested/windowsvm.json
@@ -11,7 +11,7 @@
             "type": "string"
         },
          "windowsVmSize": {
-            "defaultValue": "Standard_D1_v2",
+            "defaultValue": "Standard_A2_v2",
             "type": "string"
         },
         "imagePublisher": {

--- a/nested/windowsvm.json
+++ b/nested/windowsvm.json
@@ -4,38 +4,7 @@
     "parameters": {
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
        "windowsvm_name": {
             "defaultValue": "windowsvm",

--- a/nested/xg-nicA.json
+++ b/nested/xg-nicA.json
@@ -8,38 +8,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "Port_PrivateIp": {
             "defaultValue": "172.18.0.4",

--- a/nested/xg-nicB.json
+++ b/nested/xg-nicB.json
@@ -8,38 +8,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "Port_PrivateIp": {
             "defaultValue": "172.18.1.4",

--- a/nested/xgvm.json
+++ b/nested/xgvm.json
@@ -28,7 +28,7 @@
             "type": "string"
         },
          "imageSKU": {
-            "defaultValue": "payg",
+            "defaultValue": "payg-new",
             "type": "string"
         },
         "storageAccountName": {

--- a/nested/xgvm.json
+++ b/nested/xgvm.json
@@ -60,7 +60,7 @@
             "apiVersion": "2015-06-15",
             "location": "[parameters('location')]",
             "plan": {
-                "name": "payg",
+                "name": "payg-new",
                 "product": "sophos-xg",
                 "publisher": "sophos"
             },

--- a/nested/xgvm.json
+++ b/nested/xgvm.json
@@ -4,38 +4,7 @@
     "parameters": {
         "location": {
             "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "Brazil South",
-                "brazilsouth",
-                "East Asia",
-                "eastasia",
-                "East US",
-                "eastus",
-                "Japan East",
-                "japaneast",
-                "Japan West",
-                "japanwest",
-                "North Central US",
-                "northcentralus",
-                "North Europe",
-                "northeurope",
-                "South Central US",
-                "southcentralus",
-                "West Europe",
-                "westeurope",
-                "West US",
-                "westus",
-                "Southeast Asia",
-                "southeastasia",
-                "Central US",
-                "centralus",
-                "East US 2",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployment Location Hint: Use lowercase for creating ipaddress"
-            }
+            "defaultValue": "westus"
         },
         "availabilitySetName": {
             "type": "string",


### PR DESCRIPTION
Investigated cause, found location constraints in nested templates to list out-of-date locations.
Changed nested templates to no longer list allowedValues for location and instead take location from upstream master template.